### PR TITLE
Fix bug in time serialization format

### DIFF
--- a/astropydantic/__init__.py
+++ b/astropydantic/__init__.py
@@ -1,5 +1,6 @@
 UNIT_STRING_FORMAT = "vounit"  # Must be at the top to prevent circular imports
 TIME_OUTPUT_FORMAT = "isot_9"  # Must be at the top to prevent circular imports
+TIME_OUTPUT_SCALE = "utc"
 
 from .quantity import AstroPydanticQuantity  # noqa: E402 I001
 from .unit import AstroPydanticUnit  # noqa: E402 I001


### PR DESCRIPTION
`.value` use whatever format the value is in, not `datetime`.

We need to explicitly chose the correct format.

Fixes #2